### PR TITLE
Ldif File update

### DIFF
--- a/ForestManagement/ForestManagement.psd1
+++ b/ForestManagement/ForestManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'ForestManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.0.6'
+	ModuleVersion = '1.0.7'
 	
 	# ID used to uniquely identify this module
 	GUID = '7de4379d-17c8-48d3-bd6d-93279aef64bb'

--- a/ForestManagement/ForestManagement.psd1
+++ b/ForestManagement/ForestManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'ForestManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.0.7'
+	ModuleVersion = '1.0.11'
 	
 	# ID used to uniquely identify this module
 	GUID = '7de4379d-17c8-48d3-bd6d-93279aef64bb'

--- a/ForestManagement/changelog.md
+++ b/ForestManagement/changelog.md
@@ -1,5 +1,12 @@
 ﻿# Changelog
 
+## ???
+
+- Upd: Test-FMSchemaLdif - writes a warning when testing an object that has nocreation operation assigned, just modify, and is missing in AD.
+- Upd: Register-FMSchemaLdif - supports specifying the order it is applied at and the configuration Context that provided the settings.
+- Upd: Register-FMSchemaLdif - supports specifying objects, which will not trigger an alert if they are missing.
+- Fix: Test-FMSchemaLdif - fails when comparing certain property-types.
+
 ## 1.0.6 (2020-01-27)
 
 - Metadata update

--- a/ForestManagement/changelog.md
+++ b/ForestManagement/changelog.md
@@ -1,11 +1,12 @@
 ﻿# Changelog
 
-## ???
+## 1.0.11 (2020-03-02)
 
 - Upd: Test-FMSchemaLdif - writes a warning when testing an object that has nocreation operation assigned, just modify, and is missing in AD.
 - Upd: Register-FMSchemaLdif - supports specifying the order it is applied at and the configuration Context that provided the settings.
 - Upd: Register-FMSchemaLdif - supports specifying objects, which will not trigger an alert if they are missing.
 - Fix: Test-FMSchemaLdif - fails when comparing certain property-types.
+- Fix: Invoke-FMSchemaLdif - respects designed order of application
 
 ## 1.0.6 (2020-01-27)
 

--- a/ForestManagement/en-us/strings.psd1
+++ b/ForestManagement/en-us/strings.psd1
@@ -63,6 +63,7 @@
 	'Test-FMSchema.Connect.Failed' = 'Failed to connect to {0}' # $Server
 	'Test-FMSchema.ReadOnly.Delta' = 'There is a discrepancy in the Read-Only property {0}: Found {1} when it should be {2}' # 'LdapDisplayName', $schemaObject.lDAPDisplayName, $schemaSetting.LdapDisplayName
 	'Test-FMSchemaLdif.Connect.Failed' = 'Failed to connect to {0}' # $Server
+	'Test-FMSchemaLdif.Missing.SchemaItem' = 'Defining changes for {0} when object has not been defined and does not exist!' # $attributeName
 	'Test-FMServer.SiteConflict' = 'Found a site conflict on DC {0} : Is in site {2} and could also be in {1} ({3})' # $domainController.Name, $foundSubnet.SiteName, $domainController.SiteName, $foundSubnet.Name
 
 	'Test-FMSiteLink.Critical.TooManySites' = 'Critical issue when scanning sitelinks: The following link contains more than two sites ({1}): "{0}". This is not a technical error, but violates configuration policies. Manually update this sitelink-settings in AD to resolve the issue.' # $siteLink.DistinguishedName, $siteLink.siteList.Count

--- a/ForestManagement/functions/schemaLdif/Register-FMSchemaLdif.ps1
+++ b/ForestManagement/functions/schemaLdif/Register-FMSchemaLdif.ps1
@@ -12,6 +12,22 @@
 		
 		.PARAMETER Path
 			The path to the file to register.
+
+		.PARAMETER Weight
+			Ldif files will be applied in a certain order.
+			The weight of an Ldif file determines, the order it is applied in.
+			The lower the number, the earlier the file will be applied.
+
+			Default: 50
+
+		.PARAMETER MissingObjectExemption
+			Testing in a forest will cause it to complain about all objects the ldif file tries to modify, not create and doesn't exist.
+			Using this parameter you can exempt individual classes from triggering this warning.
+
+		.PARAMETER ContextName
+			The name of the context defining the setting.
+			This allows determining the configuration set that provided this setting.
+			Used by the ADMF, available to any other configuration management solution.
 		
 		.EXAMPLE
 			PS C:\> Register-FMSchemaLdif -Name Skype -Path "$PSScriptRoot\skype.ldif"
@@ -28,7 +44,16 @@
 		[Parameter(Mandatory = $true)]
 		[PsfValidateScript('ForestManagement.Validate.Path.SingleFile', ErrorString = 'ForestManagement.Validate.Path.SingleFile.Failed')]
 		[string]
-		$Path
+		$Path,
+
+		[int]
+		$Weight = 50,
+
+		[string[]]
+		$MissingObjectExemption,
+
+		[string]
+		$ContextName = '<Undefined>'
 	)
 	
 	begin
@@ -42,6 +67,9 @@
 			Name = $Name
 			Path = $resolvedPath
 			Settings = (Import-LdifFile -Path $Path)
+			MissingObjectExemption = ($MissingObjectExemption | ForEach-Object { $_ -replace '(^CN=)|(^)','CN=' })
+			Weight = $Weight
+			ContextName = $ContextName
 		}
 	}
 }

--- a/ForestManagement/functions/schemaLdif/Test-FMSchemaLdif.ps1
+++ b/ForestManagement/functions/schemaLdif/Test-FMSchemaLdif.ps1
@@ -160,7 +160,7 @@
 				}
 			}
 		}
-		foreach ($schemaName in $changes.Keys) {
+		$ldifResult = foreach ($schemaName in $changes.Keys) {
 			if (-not $changes[$schemaName]) { continue }
 
 			[PSCustomObject]@{
@@ -175,5 +175,6 @@
 				Configuration = ($ldifSorted | Where-Object Name -eq $schemaName)
 			}
 		}
+		$ldifResult | Sort-Object { $_.Configuration.Weight }
 	}
 }

--- a/ForestManagement/internal/functions/Compare-SchemaProperty.ps1
+++ b/ForestManagement/internal/functions/Compare-SchemaProperty.ps1
@@ -29,7 +29,8 @@
         PS C:\> Compare-SchemaProperty -Setting $setting -ADObject $adObject -PropertyName attributeSecurityGUID -RootDSE $rootDSE
 
         Returns, whether the values found in $setting and $adObject are different from each other.
-    #>
+	#>
+	[OutputType([System.Boolean])]
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true)]

--- a/ForestManagement/internal/functions/Compare-SchemaProperty.ps1
+++ b/ForestManagement/internal/functions/Compare-SchemaProperty.ps1
@@ -60,22 +60,22 @@
         }
         'Description' {
             # Prevent encoding errors / issues from falsifying the results
-            if (($null -eq $Setting.$PropertyName) -and ($null -eq $ADObject.$PropertyName)) { return $false }
+            if (($null -eq $Setting.$PropertyName) -and ($null -eq ($ADObject.$PropertyName | Select-Object -Unique))) { return $false }
             if ($null -eq $Setting.$PropertyName) { return $true }
-            if ($null -eq $ADObject.$PropertyName) { return $true }
+            if ($null -eq ($ADObject.$PropertyName | Select-Object -Unique)) { return $true }
             return (($Setting.$PropertyName -replace "[^\d\w]","_") -ne ($ADObject.$PropertyName -replace "[^\d\w]","_"))
         }
         'mayContain' {
-            if (($null -eq $Setting.$PropertyName) -and ($null -eq $ADObject.$PropertyName)) { return $false }
+            if (($null -eq $Setting.$PropertyName) -and ($null -eq ($ADObject.$PropertyName | Select-Object -Unique))) { return $false }
             if ($null -eq $Setting.$PropertyName) { return $true }
-            if ($null -eq $ADObject.$PropertyName) { return $true }
-            return [bool](Compare-Object $Setting.$PropertyName $ADObject.$PropertyName | Where-Object SideIndicator -eq '<=')
+            if ($null -eq ($ADObject.$PropertyName | Select-Object -Unique)) { return $true }
+            return [bool](Compare-Object ($Setting.$PropertyName | Select-Object -Unique) ($ADObject.$PropertyName | Select-Object -Unique) | Where-Object SideIndicator -eq '<=')
         }
         default {
-            if (($null -eq $Setting.$PropertyName) -and ($null -eq $ADObject.$PropertyName)) { return $false }
+            if (($null -eq $Setting.$PropertyName) -and ($null -eq ($ADObject.$PropertyName | Select-Object -Unique))) { return $false }
             if ($null -eq $Setting.$PropertyName) { return $true }
-            if ($null -eq $ADObject.$PropertyName) { return $true }
-            if ($Add) { return [bool](Compare-Object $Setting.$PropertyName $ADObject.$PropertyName | Where-Object SideIndicator -eq '<=') }
+            if ($null -eq ($ADObject.$PropertyName | Select-Object -Unique)) { return $true }
+            if ($Add) { return [bool](Compare-Object ($Setting.$PropertyName | Select-Object -Unique) ($ADObject.$PropertyName | Select-Object -Unique) | Where-Object SideIndicator -eq '<=') }
             return [bool](Compare-Object $Setting.$PropertyName $ADObject.$PropertyName)
         }
     }

--- a/ForestManagement/internal/functions/Compare-SchemaProperty.ps1
+++ b/ForestManagement/internal/functions/Compare-SchemaProperty.ps1
@@ -1,0 +1,82 @@
+﻿function Compare-SchemaProperty {
+    <#
+    .SYNOPSIS
+        Compares configuration vs. adobject of schema attributes.
+    
+    .DESCRIPTION
+        Compares configuration vs. adobject of schema attributes.
+        Designed for use when comparing schema attributes, for example in Test-FMSchemaLdif.
+
+        Returns $true when the values are INEQUAL.
+    
+    .PARAMETER Setting
+        The settings object containing the desired state for an attribute.
+    
+    .PARAMETER ADObject
+        The ADObject of the attribute to compare.
+    
+    .PARAMETER PropertyName
+        The property to compare.
+    
+    .PARAMETER RootDSE
+        The RootDSE object connected to.
+        Used for objectCategory comparisons.
+
+    .PARAMETER Add
+        Is satisfied with the defined items being part of the AD object property, without requiring an exact match between configuration and ad.
+    
+    .EXAMPLE
+        PS C:\> Compare-SchemaProperty -Setting $setting -ADObject $adObject -PropertyName attributeSecurityGUID -RootDSE $rootDSE
+
+        Returns, whether the values found in $setting and $adObject are different from each other.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        $Setting,
+        [Parameter(Mandatory=$true)]
+        $ADObject,
+        [Parameter(Mandatory=$true)]
+        $PropertyName,
+        [Parameter(Mandatory=$true)]
+        $RootDSE,
+        [switch]
+        $Add
+    )
+
+    switch ($PropertyName) {
+        'schemaIDGUID' {
+            return (($Setting.$PropertyName.GuidData -join '|') -ne ($ADObject.$PropertyName -join '|'))
+        }
+        'attributeSecurityGUID' {
+            return (($Setting.$PropertyName.GuidData -join '|') -ne ($ADObject.$PropertyName -join '|'))
+        }
+        'objectCategory' {
+            return (($Setting.$PropertyName -replace '<SchemaContainerDN>',$RootDSE.schemaNamingContext) -ne ($ADObject.$PropertyName -join '|'))
+        }
+        'DistinguishedName' {
+            # Don't compare identifiers!
+            return $false
+        }
+        'Description' {
+            # Prevent encoding errors / issues from falsifying the results
+            if (($null -eq $Setting.$PropertyName) -and ($null -eq $ADObject.$PropertyName)) { return $false }
+            if ($null -eq $Setting.$PropertyName) { return $true }
+            if ($null -eq $ADObject.$PropertyName) { return $true }
+            return (($Setting.$PropertyName -replace "[^\d\w]","_") -ne ($ADObject.$PropertyName -replace "[^\d\w]","_"))
+        }
+        'mayContain' {
+            if (($null -eq $Setting.$PropertyName) -and ($null -eq $ADObject.$PropertyName)) { return $false }
+            if ($null -eq $Setting.$PropertyName) { return $true }
+            if ($null -eq $ADObject.$PropertyName) { return $true }
+            return [bool](Compare-Object $Setting.$PropertyName $ADObject.$PropertyName | Where-Object SideIndicator -eq '<=')
+        }
+        default {
+            if (($null -eq $Setting.$PropertyName) -and ($null -eq $ADObject.$PropertyName)) { return $false }
+            if ($null -eq $Setting.$PropertyName) { return $true }
+            if ($null -eq $ADObject.$PropertyName) { return $true }
+            if ($Add) { return [bool](Compare-Object $Setting.$PropertyName $ADObject.$PropertyName | Where-Object SideIndicator -eq '<=') }
+            return [bool](Compare-Object $Setting.$PropertyName $ADObject.$PropertyName)
+        }
+    }
+}

--- a/ForestManagement/internal/functions/ConvertTo-SchemaLdifPhase.ps1
+++ b/ForestManagement/internal/functions/ConvertTo-SchemaLdifPhase.ps1
@@ -1,0 +1,190 @@
+﻿function ConvertTo-SchemaLdifPhase
+{
+    <#
+    .SYNOPSIS
+        Converts ldif files into a phased state index.
+
+    .DESCRIPTION
+        Converts ldif files into a phased state index.
+        For each phase/file for each object it calculates the resulting state after ALL commands in the file have been executed.
+        This allows stepping through the individual ldif files in the order they are to be applied and figure out the last applied deployment state.
+        
+    .PARAMETER LdifData
+        The set of Ldif file definitions as returned by Get-FMSchemaLdif
+
+    .EXAMPLE
+        PS C:\> $ldifPhases = ConvertTo-SchemaLdifPhase -LdifData (Get-FMSchemaLdif)
+
+        Returns the hashtable containing the different phases of all registered ldif files.
+    #>
+    [CmdletBinding()]
+    param (
+        $LdifData
+    )
+
+    #region Utility Functions
+    function Add-Node {
+        [CmdletBinding()]
+        param (
+            [string]
+            $DistinguishedName,
+
+            [string]
+            $LdifName,
+
+            [Hashtable]
+            $MappingTable
+        )
+
+        if (-not $MappingTable.ContainsKey($DistinguishedName)) {
+            $MappingTable[$DistinguishedName] = @{ }
+        }
+        if (-not $MappingTable[$DistinguishedName][$LdifName]) {
+            $MappingTable[$DistinguishedName][$LdifName] = @{
+                State = @{ }
+                Add = @{ }
+                Replace = @{ }
+            }
+        }
+    }
+    function Write-Change {
+        [CmdletBinding()]
+        param (
+            [string]
+            $DistinguishedName,
+
+            [string]
+            $LdifName,
+
+            $Change,
+
+            [Hashtable]
+            $MappingTable
+        )
+
+        Add-Node -DistinguishedName $DistinguishedName -LdifName $LdifName -MappingTable $MappingTable
+        $datasheet = $MappingTable[$DistinguishedName][$LdifName]
+
+        switch -regex ($Change.changetype) {
+            'add' {
+                $datasheet.State = @{ }
+                foreach ($propertyName in $Change.PSObject.Properties.Name) {
+                    if ($propertyName -in 'changeType', 'FM_OrderCount') { continue }
+                    $datasheet.State[$propertyName] = $Change.$propertyName
+                }
+            }
+            'modify' {
+                #region We already have a defined state
+                if ($datasheet.State.Count -gt 0) {
+                    if ($Change.add) {
+                        if ($datasheet.State.$($Change.add)) {
+                            $datasheet.State.$($Change.add) = @($datasheet.State.$($Change.add)) + @($Change.$($Change.add))
+                        }
+                        else {
+                            $datasheet.State[$Change.add] = $Change.$($Change.add)
+                        }
+                    }
+                    elseif ($Change.replace) {
+                        $datasheet.State[$Change.replace] = $Change.$($Change.replace)
+                    }
+                    else {
+                        foreach ($propertyName in $Change.PSObject.Properties.Name) {
+                            if ($propertyName -in 'DistinguishedName','changetype','FM_OrderCount') { continue }
+                            $datasheet.State[$propertyName] = $Change.$propertyName
+                        }
+                    }
+                }
+                #endregion We already have a defined state
+
+                #region Undefined state
+                else {
+                    if ($Change.add) {
+                        if ($datasheet.Add.$($Change.add)) {
+                            $datasheet.Add.$($Change.add) = @($datasheet.Add.$($Change.add)) + @($Change.$($Change.add))
+                        }
+                        else {
+                            $datasheet.Add[$Change.add] = $Change.$($Change.add)
+                        }
+                    }
+                    elseif ($Change.replace) {
+                        $datasheet.Replace[$Change.replace] = $Change.$($Change.replace)
+                    }
+                    else {
+                        foreach ($propertyName in $Change.PSObject.Properties.Name) {
+                            if ($propertyName -in 'DistinguishedName','changetype','FM_OrderCount') { continue }
+                            $datasheet.Replace[$propertyName] = $Change.$propertyName
+                        }
+                    }
+                }
+                #endregion Undefined state
+            }
+        }
+    }
+
+    function Copy-State {
+        [CmdletBinding()]
+        param (
+            [Hashtable]
+            $MappingTable,
+
+            [string]
+            $OldLdif,
+
+            [string]
+            $NewLdif
+        )
+
+        foreach ($name in $MappingTable.Keys) {
+            Add-Node -DistinguishedName $name -LdifName $NewLdif -MappingTable $MappingTable
+
+            foreach ($key in $MappingTable[$name][$OldLdif].State.Keys) {
+                $MappingTable[$name][$NewLdif].State[$key] = $MappingTable[$name][$OldLdif].State[$key] | Write-Output
+            }
+            foreach ($key in $MappingTable[$name][$OldLdif].Add.Keys) {
+                $MappingTable[$name][$NewLdif].Add[$key] = $MappingTable[$name][$OldLdif].Add[$key] | Write-Output
+            }
+            foreach ($key in $MappingTable[$name][$OldLdif].Replace.Keys) {
+                $MappingTable[$name][$NewLdif].Replace[$key] = $MappingTable[$name][$OldLdif].Replace[$key] | Write-Output
+            }
+        }
+    }
+
+    function Remove-NoOp {
+        [CmdletBinding()]
+        param (
+            $LdifData,
+
+            [Hashtable]
+            $MappingTable
+        )
+
+        $identities = $MappingTable.Keys | Write-Output
+        foreach ($identity in $identities) {
+            foreach ($ldifFile in $LdifData) {
+                if (-not $MappingTable[$identity][$ldifFile.Name]) { continue }
+                if ($ldifFile.Settings.DistinguishedName -contains $identity) { continue }
+                $MappingTable[$identity].Remove($ldifFile.Name)
+            }
+        }
+    }
+    #endregion Utility Functions
+
+    $mappingTable = @{ }
+
+    $sortedLdif = $ldifData | Sort-Object Weight
+    $previousLdif = ''
+    foreach ($ldifItem in $sortedLdif) {
+        if ($previousLdif) {
+            Copy-State -MappingTable $mappingTable -OldLdif $previousLdif -NewLdif $ldifItem.Name
+        }
+
+        foreach ($setting in ($ldifItem.Settings | Sort-Object FM_OrderCount)) {
+            Write-Change -DistinguishedName $setting.DistinguishedName -LdifName $ldifItem.Name -Change $setting -MappingTable $mappingTable
+        }
+
+        $previousLdif = $ldifItem.Name
+    }
+
+    Remove-NoOp -LdifData $sortedLdif -MappingTable $mappingTable
+    $mappingTable
+}

--- a/ForestManagement/internal/functions/ConvertTo-SchemaLdifPhase.ps1
+++ b/ForestManagement/internal/functions/ConvertTo-SchemaLdifPhase.ps1
@@ -16,7 +16,8 @@
         PS C:\> $ldifPhases = ConvertTo-SchemaLdifPhase -LdifData (Get-FMSchemaLdif)
 
         Returns the hashtable containing the different phases of all registered ldif files.
-    #>
+	#>
+	[OutputType([Hashtable])]
     [CmdletBinding()]
     param (
         $LdifData
@@ -150,6 +151,7 @@
     }
 
     function Remove-NoOp {
+		[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
         [CmdletBinding()]
         param (
             $LdifData,

--- a/ForestManagement/internal/functions/Import-LdifFile.ps1
+++ b/ForestManagement/internal/functions/Import-LdifFile.ps1
@@ -88,6 +88,7 @@
 		$lines = Get-Content -Path $Path
 		$currentObject = @{ }
 		$lastKey = ''
+		$orderCount = 0
 	}
 	process
 	{
@@ -102,7 +103,9 @@
 				$currentObject = @{
 					PSTypeName	      = 'ForestManagement.Schema.Ldif.Setting'
 					DistinguishedName = ($line -replace '^dn:', '').Trim() -replace ',DC=X$' -replace ',CN=Schema,CN=Configuration$'
+					FM_OrderCount     = $orderCount
 				}
+				$orderCount++
 				$lastKey = 'DistinguishedName'
 				continue
 			}

--- a/ForestManagement/internal/functions/Import-LdifFile.ps1
+++ b/ForestManagement/internal/functions/Import-LdifFile.ps1
@@ -71,6 +71,9 @@
 							GuidData = [System.Convert]::FromBase64String($Value)
 						}
 					}
+					'omObjectClass' {
+						[System.Convert]::FromBase64String($Value)
+					}
 					default { [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Value)) }
 				}
 			}

--- a/ForestManagement/tests/general/FileIntegrity.Exceptions.ps1
+++ b/ForestManagement/tests/general/FileIntegrity.Exceptions.ps1
@@ -28,7 +28,7 @@ $global:MayContainCommand = @{
 	"Write-Verbose" = @()
 	"Write-Warning" = @()
 	"Write-Error"  = @()
-	"Write-Output" = @('Invoke-FMSchema.ps1', 'Invoke-FMSchemaLdif.ps1')
+	"Write-Output" = @('ConvertTo-SchemaLdifPhase.ps1', 'Invoke-FMSchema.ps1', 'Invoke-FMSchemaLdif.ps1', 'Test-FMSchemaLdif.ps1')
 	"Write-Information" = @()
 	"Write-Debug" = @()
 }

--- a/ForestManagement/xml/ForestManagement.Format.ps1xml
+++ b/ForestManagement/xml/ForestManagement.Format.ps1xml
@@ -87,6 +87,37 @@
             </TableControl>
         </View>
 
+        <!-- ForestManagement.SchemaLdif.Configuration -->
+        <View>
+            <Name>ForestManagement.SchemaLdif.Configuration</Name>
+            <ViewSelectedBy>
+                <TypeName>ForestManagement.SchemaLdif.Configuration</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <AutoSize/>
+                <TableHeaders>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Name</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Weight</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>ContextName</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+
         <!-- ForestManagement.SiteLink.Configuration -->
         <View>
             <Name>ForestManagement.SiteLink.Configuration</Name>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# DCManagement
+﻿# Forest Management
 
 ## Synopsis
 


### PR DESCRIPTION
- Upd: Test-FMSchemaLdif - writes a warning when testing an object that has nocreation operation assigned, just modify, and is missing in AD.
- Upd: Register-FMSchemaLdif - supports specifying the order it is applied at and the configuration Context that provided the settings.
- Upd: Register-FMSchemaLdif - supports specifying objects, which will not trigger an alert if they are missing.
- Fix: Test-FMSchemaLdif - fails when comparing certain property-types.
- Fix: Invoke-FMSchemaLdif - respects designed order of application