### PR TITLE
1.5.54

### DIFF
--- a/ForestManagement/ForestManagement.psd1
+++ b/ForestManagement/ForestManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'ForestManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.5.46'
+	ModuleVersion = '1.5.54'
 	
 	# ID used to uniquely identify this module
 	GUID = '7de4379d-17c8-48d3-bd6d-93279aef64bb'
@@ -26,12 +26,12 @@
 	# Modules that must be imported into the global environment prior to importing
 	# this module
 	RequiredModules   = @(
-		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.6.198' }
+		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.7.270' }
 		
 		# Additional Dependencies, cannot declare due to bug in dependency handling in PS5.1
 		# @{ ModuleName = 'ResolveString'; ModuleVersion = '1.0.0' }
 		# @{ ModuleName = 'Principal'; ModuleVersion = '1.0.0' }
-		# @{ ModuleName = 'ADMF.Core'; ModuleVersion = '1.0.0' }
+		# @{ ModuleName = 'ADMF.Core'; ModuleVersion = '1.1.6' }
 		# @{ ModuleName = 'DomainManagement'; ModuleVersion = '1.4.84' }
 	)
 	

--- a/ForestManagement/changelog.md
+++ b/ForestManagement/changelog.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## ???
+## 1.5.54 (2023-02-10)
 
 - Upd: Schema - almost all settings are now optional and will only be applied if set
 - Upd: Schema - new configuration option `Optional` allows modifying an existing attribute without creating a new one in an environment where it does not exist yet.

--- a/ForestManagement/changelog.md
+++ b/ForestManagement/changelog.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## ???
+
+- Fix: SchemaLdif - "Argument is null or empty" error when using an account with the `<name>@<domain>` format
+
 ## 1.5.46 (2022-09-16)
 
 - Upd: ExchangeSchema - added support for pipeline input for invocation

--- a/ForestManagement/changelog.md
+++ b/ForestManagement/changelog.md
@@ -2,6 +2,13 @@
 
 ## ???
 
+- Upd: Schema - almost all settings are now optional and will only be applied if set
+- Upd: Schema - new configuration option `Optional` allows modifying an existing attribute without creating a new one in an environment where it does not exist yet.
+- Upd: Schema - now able to remove assignments of attributes to classes, not just adding them.
+- Upd: Schema - updated test result, renaming `InEqual` to `Update`
+- Upd: Schema - updated test result, renaming `ConfigurationOnly` to `Create`
+- Upd: Schema - significantly improved user experience of `Update`-type test results
+- Fix: Schema - fails to update a schema attribute where one or more attributes that are system protected are not equal to requirements.
 - Fix: SchemaLdif - "Argument is null or empty" error when using an account with the `<name>@<domain>` format
 
 ## 1.5.46 (2022-09-16)

--- a/ForestManagement/en-us/strings.psd1
+++ b/ForestManagement/en-us/strings.psd1
@@ -42,7 +42,7 @@
 	'Invoke-FMNTAuthStore.Remove'                                 = 'Removing certificate from the NTAuthStore: {0}' # $testResult.ADObject.Subject
 	'Invoke-FMNTAuthStore.WinRM.Failed'                           = 'Failed to connect to {0} via WinRM' # $computerName
 	
-	'Invoke-FMSchema.Assigning.Attribute.ToObjectClass'           = 'Assigning attribute to object class {0}' # $class
+	'Invoke-FMSchema.Assigning.Attribute.ToObjectClass'           = 'Assigning attribute {1} to object class {0}' # $class, $testItem.Identity
 	'Invoke-FMSchema.Connect.Failed'                              = 'Failed to connect to {0}' # $Server
 	'Invoke-FMSchema.Creating.Attribute'                          = 'Creating a new schema attribute' # 
 	'Invoke-FMSchema.Credentials.Test'                            = 'Testing ADWS connectivity to the Schema Master' # 
@@ -51,6 +51,7 @@
 	'Invoke-FMSchema.Decommission.MustContain'                    = 'Removing attribute {0} from class''s {1} MustContain attribute' # $testItem.ADObject.LdapDisplayName, $adObject.LdapDisplayName
 	'Invoke-FMSchema.Reading.ObjectClass.Failed'                  = 'Error searching for object class {0}' # $class
 	'Invoke-FMSchema.Reading.ObjectClass.NotFound'                = 'Failed to find object class {0}' # $class
+	'Invoke-FMSchema.Removing.Attribute.FromObjectClass'          = 'Removing attribute {1} from object class: {0}' # $class, $testItem.Identity
 	'Invoke-FMSchema.Rename.Attribute'                            = 'Renaming attribute {0} to {1}' # $testItem.ADObject.cn, $testItem.Configuration.Name
 	'Invoke-FMSchema.Schema.Credentials'                          = 'Resolving credentials for schema administration' # 
 	'Invoke-FMSchema.Schema.Credentials.Release'                  = 'Releasing/Postprocessing credentials used for schema administration' # 
@@ -103,6 +104,7 @@
 	'Remove-SchemaAdminCredential.TemporaryAccount.Remove'        = 'Removing temporary schema admin account {0}' # $script:temporarySchemaUpdateUser.Name
 	'Remove-SchemaAdminCredential.TemporaryAccount.Remove.Failed' = 'Failed to remove temporary schema admin account {0}' # $script:temporarySchemaUpdateUser.Name
 	
+	'Resolve-SchemaAttribute.Update.SystemOnlyError'              = 'Cannot update {0} to {1} on {2}. The attribute property is system protected and can only ever be defined when creating a new attribute! This cannot be undone and only replacing the attribute with a new attribute will allow you to resolve the issue.' # $attributeName, $attributes.$attributeName, $ADObject
 	'Test-FMSchema.Connect.Failed'                                = 'Failed to connect to {0}' # $Server
 	
 	'Test-FMSchemaDefaultPermission.Class.IdentityUncertain'      = 'Unable to resolve all identities for the default permissions to apply to {0}. This objectclass will be skipped instead.' # $Configuration[0].ClassName

--- a/ForestManagement/functions/schema/Invoke-FMSchema.ps1
+++ b/ForestManagement/functions/schema/Invoke-FMSchema.ps1
@@ -147,11 +147,11 @@
 
 				#region Update Schema Attribute
 				'Update' {
-					$resolvedAttributes = Resolve-SchemaAttribute -Configuration $testItem.Configuration -ADObject $testItem.ADObject
+					$resolvedAttributes = Resolve-SchemaAttribute -Configuration $testItem.Configuration -ADObject $testItem.ADObject -Changes $testItem.Changed
 					if ($resolvedAttributes.Keys.Count -ge 1) {
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-FMSchema.Updating.Attribute' -ActionStringValues ($resolvedAttributes.Keys -join ', ') -Target $testItem.Identity -ScriptBlock {
 							$testItem.ADObject | Set-ADObject @parameters -Replace $resolvedAttributes -ErrorAction Stop
-						} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
+						} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
 					}
 
 					# Do not process MayContain for defunct attributes

--- a/ForestManagement/functions/schema/Invoke-FMSchema.ps1
+++ b/ForestManagement/functions/schema/Invoke-FMSchema.ps1
@@ -178,7 +178,7 @@
 						catch { Stop-PSFFunction -String 'Invoke-FMSchema.Reading.ObjectClass.Failed' -StringValues $class -EnableException $EnableException -Continue -ErrorRecord $_ }
 						if (-not $classObject) { Stop-PSFFunction -String 'Invoke-FMSchema.Reading.ObjectClass.NotFound' -StringValues $class -EnableException $EnableException -Continue }
 	
-						if ($classObject.mayContain -notcontains $testItem.ADObject.LdapDisplayName) {
+						if ($classObject.mayContain -contains $testItem.ADObject.LdapDisplayName) {
 							Invoke-PSFProtectedCommand -ActionString 'Invoke-FMSchema.Removing.Attribute.FromObjectClass' -ActionStringValues $class, $testItem.Identity -Target $testItem.Identity -ScriptBlock {
 								$classObject | Set-ADObject @parameters -Remove @{ mayContain = $testItem.ADObject.LdapDisplayName } -ErrorAction Stop
 							} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue

--- a/ForestManagement/functions/schema/Register-FMSchema.ps1
+++ b/ForestManagement/functions/schema/Register-FMSchema.ps1
@@ -50,6 +50,10 @@
 		Flag this attribute as defunct.
 		It will be marked as such in AD, be delisted from the Global Catalog and removed from all its supposed memberships.
 
+	.PARAMETER Optional
+		By default, all defined schema attributes must exist.
+		By setting a schema attribute optional, it will be tolerated if it exists, but not created if it does not.
+
 	.PARAMETER ContextName
 		The name of the context defining the setting.
 		This allows determining the configuration set that provided this setting.
@@ -62,7 +66,7 @@
 #>
 	[CmdletBinding()]
 	Param (
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[AllowEmptyCollection()]
 		[string[]]
 		$ObjectClass,
@@ -71,11 +75,11 @@
 		[string]
 		$OID,
 		
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[string]
 		$AdminDisplayName,
 		
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[string]
 		$LdapDisplayName,
 
@@ -83,37 +87,41 @@
 		[string]
 		$Name,
 		
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[int]
 		$OMSyntax,
 		
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[string]
 		$AttributeSyntax,
 		
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[switch]
 		$SingleValued,
 		
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[string]
 		$AdminDescription,
 		
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[int]
 		$SearchFlags,
 		
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[bool]
 		$PartialAttributeSet,
 		
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[bool]
 		$AdvancedView,
 
 		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[bool]
 		$IsDefunct,
+
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[bool]
+		$Optional,
 
 		[string]
 		$ContextName = '<Undefined>'
@@ -123,22 +131,11 @@
 		$nameResult = $Name
 		if (-not $Name) { $nameResult = $AdminDisplayName }
 
-		$script:schema[$OID] = [PSCustomObject]@{
-			PSTypeName          = 'ForestManagement.Schema.Configuration'
-			ObjectClass         = $ObjectClass
-			OID                 = $OID
-			AdminDisplayName    = $AdminDisplayName
-			LdapDisplayName     = $LdapDisplayName
-			Name                = $nameResult
-			OMSyntax            = $OMSyntax
-			AttributeSyntax     = $AttributeSyntax
-			SingleValued        = $SingleValued
-			AdminDescription    = $AdminDescription
-			SearchFlags         = $SearchFlags
-			PartialAttributeSet = $PartialAttributeSet
-			AdvancedView        = $AdvancedView
-			IsDefunct           = $IsDefunct
-			ContextName         = $ContextName
-		}
+		$hashtable = $PSBoundParameters | ConvertTo-PSFHashtable
+		$hashtable.ContextName = $ContextName
+		$hashtable.PSTypeName = 'ForestManagement.Schema.Configuration'
+		if ($nameResult) { $hashtable.Name = $nameResult }
+
+		$script:schema[$OID] = [PSCustomObject]$hashtable
 	}
 }

--- a/ForestManagement/internal/functions/Invoke-LdifFile.ps1
+++ b/ForestManagement/internal/functions/Invoke-LdifFile.ps1
@@ -56,8 +56,13 @@
 		if ($Credential) {
 			$arguments += "-b"
 			$networkCredential = $Credential.GetNetworkCredential()
-			$arguments += $networkCredential.UserName
-			$arguments += $networkCredential.Domain
+			$userName = $networkCredential.UserName
+			$domain = $networkCredential.Domain
+			if (-not $domain -and $userName -match '@') {
+				$userName, $domain = $userName -split '@',2
+			}
+			$arguments += $userName
+			if ($domain) { $arguments += $domain }
 			$arguments += $networkCredential.Password
 		}
 		#  Load target server

--- a/ForestManagement/internal/functions/Resolve-SchemaAttribute.ps1
+++ b/ForestManagement/internal/functions/Resolve-SchemaAttribute.ps1
@@ -1,5 +1,4 @@
-﻿function Resolve-SchemaAttribute
-{
+﻿function Resolve-SchemaAttribute {
 	<#
 	.SYNOPSIS
 		Combines configuration and adobject into an attributes hashtable.
@@ -33,34 +32,51 @@
 		$ADObject
 	)
 	
-	process
-	{
+	process {
 		#region Build out basic attribute hashtable
 		$attributes = @{
-			adminDisplayName = $Configuration.AdminDisplayName
-			lDAPDisplayName  = $Configuration.LdapDisplayName
-			attributeId	     = $Configuration.OID
-			oMSyntax		 = $Configuration.OMSyntax
-			attributeSyntax  = $Configuration.AttributeSyntax
-			isSingleValued   = ($Configuration.SingleValued -as [bool])
-			adminDescription = $Configuration.AdminDescription
-			searchflags	     = $Configuration.SearchFlags
+			adminDisplayName              = $Configuration.AdminDisplayName
+			lDAPDisplayName               = $Configuration.LdapDisplayName
+			attributeId                   = $Configuration.OID
+			oMSyntax                      = $Configuration.OMSyntax
+			attributeSyntax               = $Configuration.AttributeSyntax
+			isSingleValued                = ($Configuration.SingleValued -as [bool])
+			adminDescription              = $Configuration.AdminDescription
+			searchflags                   = $Configuration.SearchFlags
 			isMemberOfPartialAttributeSet = $Configuration.PartialAttributeSet
-			showInAdvancedViewOnly = $Configuration.AdvancedView
+			showInAdvancedViewOnly        = $Configuration.AdvancedView
 		}
 		#endregion Build out basic attribute hashtable
+
+		if (-not $ADObject) { return $attributes }
 		
 		#region If ADObject is present: Remove attributes that are already present
-		$attributeNames = 'isSingleValued', 'searchflags', 'isMemberOfPartialAttributeSet', 'oMSyntax', 'attributeId', 'adminDescription', 'adminDisplayName', 'showInAdvancedViewOnly', 'lDAPDisplayName', 'attributeSyntax'
-		
-		if ($ADObject)
-		{
-			foreach ($attributeName in $attributeNames)
-			{
-				if ($ADobject.$attributeName -ceq $attributes[$attributeName])
-				{
-					$attributes.Remove($attributeName)
-				}
+		$attributeNames = @(
+			'isSingleValued'
+			'searchflags'
+			'isMemberOfPartialAttributeSet'
+			'oMSyntax'
+			'attributeId'
+			'adminDescription'
+			'adminDisplayName'
+			'showInAdvancedViewOnly'
+			'lDAPDisplayName'
+			'attributeSyntax'
+		)
+		$systemOnly = @(
+			'isSingleValued'
+			'oMSyntax'
+			'attributeId'
+			'attributeSyntax'
+		)
+
+		foreach ($attributeName in $attributeNames) {
+			if ($ADObject.$attributeName -ceq $attributes[$attributeName]) {
+				$attributes.Remove($attributeName)
+			}
+			if ($attributes.Keys -contains $attributeName -and $systemOnly -contains $attributeName) {
+				Write-PSFMessage -Level Warning -String 'Resolve-SchemaAttribute.Update.SystemOnlyError' -StringValues $attributeName, $attributes.$attributeName, $ADObject
+				$attributes.Remove($attributeName)
 			}
 		}
 		#endregion If ADObject is present: Remove attributes that are already present

--- a/ForestManagement/internal/functions/Resolve-SchemaAttribute.ps1
+++ b/ForestManagement/internal/functions/Resolve-SchemaAttribute.ps1
@@ -39,6 +39,7 @@
 
 	begin {
 		function Convert-AttributeName {
+			[OutputType([string])]
 			[CmdletBinding()]
 			param (
 				[Parameter(ValueFromPipeline = $true)]

--- a/ForestManagement/tests/general/FileIntegrity.Exceptions.ps1
+++ b/ForestManagement/tests/general/FileIntegrity.Exceptions.ps1
@@ -28,7 +28,7 @@ $global:MayContainCommand = @{
 	"Write-Verbose" = @()
 	"Write-Warning" = @()
 	"Write-Error"  = @()
-	"Write-Output" = @('ConvertTo-SchemaLdifPhase.ps1', 'Invoke-FMSchema.ps1', 'Invoke-FMSchemaLdif.ps1', 'Test-FMSchemaLdif.ps1', 'Invoke-FMSchemaDefaultPermission.ps1')
+	"Write-Output" = @('ConvertTo-SchemaLdifPhase.ps1', 'Invoke-FMSchema.ps1', 'Invoke-FMSchemaLdif.ps1', 'Test-FMSchemaLdif.ps1', 'Invoke-FMSchemaDefaultPermission.ps1', 'Resolve-SchemaAttribute.ps1')
 	"Write-Information" = @()
 	"Write-Debug" = @()
 }


### PR DESCRIPTION
- Upd: Schema - almost all settings are now optional and will only be applied if set
- Upd: Schema - new configuration option `Optional` allows modifying an existing attribute without creating a new one in an environment where it does not exist yet.
- Upd: Schema - now able to remove assignments of attributes to classes, not just adding them.
- Upd: Schema - updated test result, renaming `InEqual` to `Update`
- Upd: Schema - updated test result, renaming `ConfigurationOnly` to `Create`
- Upd: Schema - significantly improved user experience of `Update`-type test results
- Fix: Schema - fails to update a schema attribute where one or more attributes that are system protected are not equal to requirements.
- Fix: SchemaLdif - "Argument is null or empty" error when using an account with the `<name>@<domain>` format