### PR TITLE
1.5.66

### DIFF
--- a/ForestManagement/ForestManagement.psd1
+++ b/ForestManagement/ForestManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'ForestManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.5.59'
+	ModuleVersion = '1.5.66'
 	
 	# ID used to uniquely identify this module
 	GUID = '7de4379d-17c8-48d3-bd6d-93279aef64bb'

--- a/ForestManagement/changelog.md
+++ b/ForestManagement/changelog.md
@@ -1,5 +1,15 @@
 ﻿# Changelog
 
+## 1.5.66 (2023-09-27)
+
+- Upd: Certificates - added support to provide the context name
+- Upd: Exchange Schema - setup will now always use the local DC for domain interaction
+- Upd: Forest Level - will automatically target the Domain Naming Master FSMO holder (as it needs to)
+- Fix: Schema - fails to use credentials when renaming an attribute
+- Fix: Exchange Schema - split permission test results will be ignored when invoking
+- Fix: Exchange Schema - split permission processing for child domains is incorrect
+- Fix: Exchange Schema - fails to apply changes without error due to bad exitcodes from setup.exe
+
 ## 1.5.59 (2023-06-01)
 
 - Fix: Test-FMSchema - test results would lead to unexpected error on updates

--- a/ForestManagement/functions/certificates/Register-FMCertificate.ps1
+++ b/ForestManagement/functions/certificates/Register-FMCertificate.ps1
@@ -1,5 +1,4 @@
-﻿function Register-FMCertificate
-{
+﻿function Register-FMCertificate {
 	<#
 		.SYNOPSIS
 			Register directory services certificates
@@ -19,6 +18,11 @@
 	
 		.PARAMETER Remove
 			Thumbprint of a certificate to remove rather than add.
+
+		.PARAMETER ContextName
+			The name of the context defining the setting.
+			This allows determining the configuration set that provided this setting.
+			Used by the ADMF, available to any other configuration management solution.
 
 		.EXAMPLE
 			PS C:\> Register-FMCertificate -Certificate $certificate -Type RootCA
@@ -52,19 +56,20 @@
 		
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Remove')]
 		[string]
-		$Remove
+		$Remove,
+
+		[string]
+		$ContextName = '<Undefined>'
 	)
 	
-	process
-	{
-		switch ($pscmdlet.ParameterSetName)
-		{
-			Certificate
-			{
+	process {
+		switch ($pscmdlet.ParameterSetName) {
+			Certificate {
 				$object = [pscustomobject]@{
 					Certificate = $Certificate
-					Type	    = $Type
-					Action	    = 'Add'
+					Type        = $Type
+					Action      = 'Add'
+					ContextName = $ContextName
 				}
 				Add-Member -InputObject $object -MemberType ScriptMethod -Name ToString -Value {
 					'+ {0} > {1}' -f $this.Type, $this.Certificate.Subject
@@ -72,12 +77,12 @@
 				$script:dsCertificates[$Certificate.Thumbprint] = $object
 			}
 			Authorative { $script:dsCertificatesAuthorative[$Type] = $Authorative }
-			Remove
-			{
+			Remove {
 				$object = [pscustomobject]@{
-					Thumbprint = $Remove
-					Type	   = $Type
-					Action	   = 'Remove'
+					Thumbprint  = $Remove
+					Type        = $Type
+					Action      = 'Remove'
+					ContextName = $ContextName
 				}
 				Add-Member -InputObject $object -MemberType ScriptMethod -Name ToString -Value {
 					'- {0} > {1}' -f $this.Type, $this.Thumbprint

--- a/ForestManagement/functions/forestlevel/Invoke-FMForestLevel.ps1
+++ b/ForestManagement/functions/forestlevel/Invoke-FMForestLevel.ps1
@@ -54,6 +54,10 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type ForestLevel -Cmdlet $PSCmdlet
+
+		# Must be executed against the Domain Naming Master
+		$forest = Get-ADForest @parameters
+		$parameters.Server = $forest.DomainNamingMaster
 	}
 	process
 	{

--- a/ForestManagement/functions/forestlevel/Test-FMForestLevel.ps1
+++ b/ForestManagement/functions/forestlevel/Test-FMForestLevel.ps1
@@ -50,7 +50,8 @@
 		$forest = Get-ADForest @parameters
 		if ($forest.ForestMode -lt $desiredLevel)
 		{
-			New-TestResult -ObjectType ForestLevel -Type Raise -Identity $forest -Server $Server -Configuration ([pscustomobject]$tempConfiguration) -ADObject $forest
+			$change = New-AdcChange -Property ForestLevel -OldValue 2008R2 -NewValue 2016 -Type ForestLevel -Identity $forest -ToString { '{0}: {1} -> {2}' -f $this.Identity, $this.Old, $this.New }
+			New-TestResult -ObjectType ForestLevel -Type Raise -Identity $forest -Server $Server -Configuration ([pscustomobject]$tempConfiguration) -ADObject $forest -Changed $change
 		}
 	}
 }

--- a/ForestManagement/functions/ntauthstore/Register-FMNTAuthStore.ps1
+++ b/ForestManagement/functions/ntauthstore/Register-FMNTAuthStore.ps1
@@ -36,7 +36,7 @@
 	)
 	
 	process {
-		switch ($pscmdlet.ParameterSetName) {
+		switch ($PSCmdlet.ParameterSetName) {
 			Certificate { $script:ntAuthStoreCertificates[$Certificate.Thumbprint] = $Certificate }
 			Authorative { $script:ntAuthStoreAuthorative = $Authorative.ToBool() }
 		}

--- a/ForestManagement/functions/schema/Invoke-FMSchema.ps1
+++ b/ForestManagement/functions/schema/Invoke-FMSchema.ps1
@@ -190,7 +190,7 @@
 				#region Rename Schema Attribute
 				'Rename' {
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-FMSchema.Rename.Attribute' -ActionStringValues $testItem.ADObject.cn, $testItem.Configuration.Name -Target $testItem -ScriptBlock {
-						$testItem.ADObject | Rename-ADObject -NewName $testItem.Configuration.Name -ErrorAction Stop
+						$testItem.ADObject | Rename-ADObject @parameters -NewName $testItem.Configuration.Name -ErrorAction Stop
 					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
 				}
 				#endregion Rename Schema Attribute


### PR DESCRIPTION
- Upd: Certificates - added support to provide the context name
- Upd: Exchange Schema - setup will now always use the local DC for domain interaction
- Upd: Forest Level - will automatically target the Domain Naming Master FSMO holder (as it needs to)
- Fix: Schema - fails to use credentials when renaming an attribute
- Fix: Exchange Schema - split permission test results will be ignored when invoking
- Fix: Exchange Schema - split permission processing for child domains is incorrect
- Fix: Exchange Schema - fails to apply changes without error due to bad exitcodes from setup.exe