### PR TITLE
1.5.70

### DIFF
--- a/ForestManagement/ForestManagement.psd1
+++ b/ForestManagement/ForestManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'ForestManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.5.66'
+	ModuleVersion = '1.5.70'
 	
 	# ID used to uniquely identify this module
 	GUID = '7de4379d-17c8-48d3-bd6d-93279aef64bb'

--- a/ForestManagement/changelog.md
+++ b/ForestManagement/changelog.md
@@ -1,5 +1,12 @@
 ﻿# Changelog
 
+## 1.5.70 (2023-09-28)
+
+- Fix: Name Resolution - string replacement will not always have the correct data to insert
+- Fix: Exchange Schema - error message is missing when catching invalid setup.exe
+- Fix: Exchange Schema - removed forced DC selection (previous change was caused by an analysis error)
+- Fix: Exchange Schema - fails to update due to Organization Name being passed in
+
 ## 1.5.66 (2023-09-27)
 
 - Upd: Certificates - added support to provide the context name

--- a/ForestManagement/en-us/strings.psd1
+++ b/ForestManagement/en-us/strings.psd1
@@ -34,6 +34,7 @@
 	'Invoke-FMExchangeSchema.WinRM.Failed'                        = 'Failed to connect to "{0}" via WinRM/PowerShell Remoting.' # $computerName
 	'Invoke-FMExchangeSchema.DisablingSplitPermissions'           = 'Disabling split permissions for {0}' # $testItem.Configuration
 	'Invoke-FMExchangeSchema.EnablingSplitPermissions'            = 'Enabling split permissions for {0}' # $testItem.Configuration
+	'Invoke-FMExchangeSchema.SchemaMaster.WrongSite'              = 'Error applying Exchange Schema update: Target server {0} must be in the same site as the Schema Master {1}' # $parameters.Server, $forest.SchemaMaster
 	
 	'Invoke-FMForestLevel.Raise.Level'                            = 'Raising forest level to {0}' # $testItem.Configuration.Level
 	

--- a/ForestManagement/functions/certificates/Invoke-FMCertificate.ps1
+++ b/ForestManagement/functions/certificates/Invoke-FMCertificate.ps1
@@ -56,6 +56,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type dsCertificates -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 		
 		$computerName = (Get-ADDomain @parameters).PDCEmulator
 		$psParameter = $PSBoundParameters | ConvertTo-PSFHashtable -Include ComputerName, Credential -Inherit

--- a/ForestManagement/functions/certificates/Test-FMCertificate.ps1
+++ b/ForestManagement/functions/certificates/Test-FMCertificate.ps1
@@ -35,6 +35,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type dsCertificates -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 	}
 	process
 	{

--- a/ForestManagement/functions/exchangeschema/Invoke-FMExchangeSchema.ps1
+++ b/ForestManagement/functions/exchangeschema/Invoke-FMExchangeSchema.ps1
@@ -54,6 +54,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type ExchangeSchema -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 		$forestObject = Get-ADForest @parameters
 		
 		$psParameter = $PSBoundParameters | ConvertTo-PSFHashtable -Include Credential
@@ -82,6 +83,21 @@
 			}
 		}
 		
+		function Test-ExchangeSite {
+			[CmdletBinding()]
+			param (
+				[hashtable]
+				$Parameters,
+
+				$Forest
+			)
+
+			$currentServer = Get-ADDomainController @parameters
+			$schemaMaster = Get-ADDomainController @parameters -Identity $Forest.SchemaMaster
+
+			$currentServer.Site -eq $schemaMaster.Site
+		}
+
 		function Invoke-ExchangeSchemaUpdate {
 			[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingEmptyCatchBlock", "")]
 			[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
@@ -136,24 +152,23 @@
 				$installPath = "$($volume.DriveLetter):\setup.exe"
 				
 				#region Perform Installation
-				$computerName = [System.Environment]::MachineName
 				$resultText = switch ($Parameters.Mode) {
-					'InstallSchema' { & $installPath /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /PrepareSchema /dc:$computerName 2>&1 }
-					'UpdateSchema' { & $installPath /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /PrepareSchema /dc:$computerName 2>&1 }
+					'InstallSchema' { & $installPath /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /PrepareSchema 2>&1 }
+					'UpdateSchema' { & $installPath /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /PrepareSchema 2>&1 }
 					'Install' {
-						if (-not $Parameters.SplitPermission) { & $installPath /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /PrepareAD /OrganizationName:$($Parameters.OrganizationName) /dc:$computerName 2>&1 }
-						else { & $installPath /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /PrepareAD /ActiveDirectorySplitPermissions:true /OrganizationName:$($Parameters.OrganizationName) /dc:$computerName 2>&1 }
+						if (-not $Parameters.SplitPermission) { & $installPath /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /PrepareAD /OrganizationName:$($Parameters.OrganizationName) 2>&1 }
+						else { & $installPath /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /PrepareAD /ActiveDirectorySplitPermissions:true /OrganizationName:$($Parameters.OrganizationName) 2>&1 }
 					}
-					'Update' { & $installPath /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /PrepareAD /OrganizationName:$($Parameters.OrganizationName) /dc:$computerName 2>&1 }
+					'Update' { & $installPath /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /PrepareAD 2>&1 }
 					'EnableSplitP' {
-						& $installPath /PrepareAD /ActiveDirectorySplitPermissions:true /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /dc:$computerName 2>&1
-						if (-not $Parameters.AllDomains) { & $installPath /PrepareDomain /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /dc:$computerName 2>&1 }
-						else { & $installPath /PrepareAllDomains /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /dc:$computerName 2>&1 }
+						& $installPath /PrepareAD /ActiveDirectorySplitPermissions:true /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF 2>&1
+						if (-not $Parameters.AllDomains) { & $installPath /PrepareDomain /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF 2>&1 }
+						else { & $installPath /PrepareAllDomains /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF 2>&1 }
 					}
 					'DisableSplitP' {
-						& $installPath /PrepareAD /ActiveDirectorySplitPermissions:false /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /dc:$computerName 2>&1
-						if (-not $Parameters.AllDomains) { & $installPath /PrepareDomain /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /dc:$computerName 2>&1 }
-						else { & $installPath /PrepareAllDomains /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF /dc:$computerName 2>&1 }
+						& $installPath /PrepareAD /ActiveDirectorySplitPermissions:false /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF 2>&1
+						if (-not $Parameters.AllDomains) { & $installPath /PrepareDomain /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF 2>&1 }
+						else { & $installPath /PrepareAllDomains /IAcceptExchangeServerLicenseTerms_DiagnosticDataOFF 2>&1 }
 					}
 				}
 				$results = [pscustomobject]@{
@@ -169,16 +184,20 @@
 				# Report result
 				$results
 			} -ArgumentList ($PSBoundParameters | ConvertTo-PSFHashtable -Exclude Session)
-			Write-PSFMessage -Message ($result.Message -join "`n") -Tag exchange, result
+			Write-PSFMessage -Message ($result.Message -join "`n") -Tag exchange, result -Target $Parameters.Server
 			if (-not $result.Success) {
 				throw "Error applying exchange update: $($result.Message)"
 			}
 
-			# Exchange#s setup.exe is not always reliable in its exit codes, thus we need to retest
-			$result = Test-FMExchangeSchema @Parameters
-			if (-not $result) { return }
-			if ($result.Type -contains $Mode) {
-				throw "Error applying exchange update: $($result.Message)"
+			# Test Message validation (Text parsing is bad, but the method below is less reliable)
+			if ($result.Message -match 'The Exchange Server setup operation completed successfully') { return }
+
+			# Exchange's setup.exe is not always reliable in its exit codes, thus we need to retest
+			# This is not guaranteed to work 100%, as replication delay may lead to false errors
+			$testResult = Test-FMExchangeSchema @Parameters
+			if (-not $testResult) { return }
+			if ($testResult.Type -contains $Mode) {
+				throw "Exchange Update probably failed! Success could not be verified, but replication delays might lead to a wrong alert here. This was the return from the exchange installer:`n$($result.Message)"
 			}
 		}
 		#endregion Functions
@@ -205,6 +224,9 @@
 					if (-not (Test-ExchangeIsoPath -Session $session -Path $testItem.Configuration.LocalImagePath)) {
 						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.IsoPath.Missing' -StringValues $testItem.Configuration.LocalImagePath -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
 					}
+					if (-not (Test-ExchangeSite -Parameters $parameters -Forest $forest)) {
+						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.SchemaMaster.WrongSite' -StringValues $parameters.Server, $forest.SchemaMaster -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
+					}
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-FMExchangeSchema.Installing' -ActionStringValues $testItem.Configuration -Target $forestObject -ScriptBlock {
 						Invoke-ExchangeSchemaUpdate @commonParam -Mode InstallSchema -SchemaOnly
 					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
@@ -215,6 +237,9 @@
 				'UpdateSchema' {
 					if (-not (Test-ExchangeIsoPath -Session $session -Path $testItem.Configuration.LocalImagePath)) {
 						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.IsoPath.Missing' -StringValues $testItem.Configuration.LocalImagePath -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
+					}
+					if (-not (Test-ExchangeSite -Parameters $parameters -Forest $forest)) {
+						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.SchemaMaster.WrongSite' -StringValues $parameters.Server, $forest.SchemaMaster -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
 					}
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-FMExchangeSchema.Updating' -ActionStringValues $testItem.ADObject, $testItem.Configuration -Target $forestObject -ScriptBlock {
 						Invoke-ExchangeSchemaUpdate @commonParam -Mode UpdateSchema -SchemaOnly
@@ -227,6 +252,9 @@
 					if (-not (Test-ExchangeIsoPath -Session $session -Path $testItem.Configuration.LocalImagePath)) {
 						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.IsoPath.Missing' -StringValues $testItem.Configuration.LocalImagePath -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
 					}
+					if (-not (Test-ExchangeSite -Parameters $parameters -Forest $forest)) {
+						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.SchemaMaster.WrongSite' -StringValues $parameters.Server, $forest.SchemaMaster -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
+					}
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-FMExchangeSchema.Installing' -ActionStringValues $testItem.Configuration -Target $forestObject -ScriptBlock {
 						Invoke-ExchangeSchemaUpdate @commonParam -Mode Install
 					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
@@ -238,6 +266,9 @@
 					if (-not (Test-ExchangeIsoPath -Session $session -Path $testItem.Configuration.LocalImagePath)) {
 						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.IsoPath.Missing' -StringValues $testItem.Configuration.LocalImagePath -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
 					}
+					if (-not (Test-ExchangeSite -Parameters $parameters -Forest $forest)) {
+						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.SchemaMaster.WrongSite' -StringValues $parameters.Server, $forest.SchemaMaster -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
+					}
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-FMExchangeSchema.Updating' -ActionStringValues $testItem.ADObject, $testItem.Configuration -Target $forestObject -ScriptBlock {
 						Invoke-ExchangeSchemaUpdate @commonParam -Mode Update
 					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
@@ -248,6 +279,9 @@
 					if (-not (Test-ExchangeIsoPath -Session $session -Path $testItem.Configuration.LocalImagePath)) {
 						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.IsoPath.Missing' -StringValues $testItem.Configuration.LocalImagePath -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
 					}
+					if (-not (Test-ExchangeSite -Parameters $parameters -Forest $forest)) {
+						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.SchemaMaster.WrongSite' -StringValues $parameters.Server, $forest.SchemaMaster -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
+					}
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-FMExchangeSchema.DisablingSplitPermissions' -ActionStringValues $testItem.Configuration -Target $Server -ScriptBlock {
 						Invoke-ExchangeSchemaUpdate @commonParam -Mode DisableSplitP -AllDomains $testItem.Configuration.AllDomains
 					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
@@ -255,6 +289,9 @@
 				'EnableSplitP' {
 					if (-not (Test-ExchangeIsoPath -Session $session -Path $testItem.Configuration.LocalImagePath)) {
 						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.IsoPath.Missing' -StringValues $testItem.Configuration.LocalImagePath -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
+					}
+					if (-not (Test-ExchangeSite -Parameters $parameters -Forest $forest)) {
+						Stop-PSFFunction -String 'Invoke-FMExchangeSchema.SchemaMaster.WrongSite' -StringValues $parameters.Server, $forest.SchemaMaster -EnableException $EnableException -Continue -Category ResourceUnavailable -Target $Server
 					}
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-FMExchangeSchema.EnablingSplitPermissions' -ActionStringValues $testItem.Configuration -Target $Server -ScriptBlock {
 						Invoke-ExchangeSchemaUpdate @commonParam -Mode EnableSplitP -AllDomains $testItem.Configuration.AllDomains

--- a/ForestManagement/functions/exchangeschema/Test-FMExchangeSchema.ps1
+++ b/ForestManagement/functions/exchangeschema/Test-FMExchangeSchema.ps1
@@ -32,6 +32,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type ExchangeSchema -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 		
 		#region Utility Functions
 		function Get-ExchangeRangeUpper {

--- a/ForestManagement/functions/forestlevel/Invoke-FMForestLevel.ps1
+++ b/ForestManagement/functions/forestlevel/Invoke-FMForestLevel.ps1
@@ -54,6 +54,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type ForestLevel -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 
 		# Must be executed against the Domain Naming Master
 		$forest = Get-ADForest @parameters

--- a/ForestManagement/functions/forestlevel/Test-FMForestLevel.ps1
+++ b/ForestManagement/functions/forestlevel/Test-FMForestLevel.ps1
@@ -34,6 +34,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type ForestLevel -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 	}
 	process
 	{

--- a/ForestManagement/functions/ntauthstore/Invoke-FMNTAuthStore.ps1
+++ b/ForestManagement/functions/ntauthstore/Invoke-FMNTAuthStore.ps1
@@ -54,6 +54,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type ntAuthStoreCertificates -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 		
 		$computerName = (Get-ADDomain @parameters).PDCEmulator
 		$psParameter = $PSBoundParameters | ConvertTo-PSFHashtable -Include ComputerName, Credential -Inherit

--- a/ForestManagement/functions/ntauthstore/Test-FMNTAuthStore.ps1
+++ b/ForestManagement/functions/ntauthstore/Test-FMNTAuthStore.ps1
@@ -33,6 +33,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type ntAuthStoreCertificates -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 
 		#region Utility Functions
 		function New-TestResult {

--- a/ForestManagement/functions/schema/Invoke-FMSchema.ps1
+++ b/ForestManagement/functions/schema/Invoke-FMSchema.ps1
@@ -58,6 +58,8 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type Schema -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
+
 		try { $rootDSE = Get-ADRootDSE @parameters -ErrorAction Stop }
 		catch {
 			Stop-PSFFunction -String 'Invoke-FMSchema.Connect.Failed' -StringValues $Server -ErrorRecord $_ -EnableException $EnableException -Exception $_.Exception.GetBaseException()

--- a/ForestManagement/functions/schema/Test-FMSchema.ps1
+++ b/ForestManagement/functions/schema/Test-FMSchema.ps1
@@ -41,6 +41,8 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type Schema -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
+
 		try { $rootDSE = Get-ADRootDSE @parameters -ErrorAction Stop }
 		catch {
 			Stop-PSFFunction -String 'Test-FMSchema.Connect.Failed' -StringValues $Server -ErrorRecord $_ -EnableException $EnableException -Exception $_.Exception.GetBaseException()

--- a/ForestManagement/functions/schemaLdif/Invoke-FMSchemaLdif.ps1
+++ b/ForestManagement/functions/schemaLdif/Invoke-FMSchemaLdif.ps1
@@ -56,6 +56,8 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type SchemaLdif -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
+		
 		try {
 			$forest = Get-ADForest @parameters -ErrorAction Stop
 		}

--- a/ForestManagement/functions/schemaLdif/Test-FMSchemaLdif.ps1
+++ b/ForestManagement/functions/schemaLdif/Test-FMSchemaLdif.ps1
@@ -42,6 +42,8 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type SchemaLdif -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
+		
 		try {
 			$rootDSE = Get-ADRootDSE @parameters -ErrorAction Stop
 			$forest = Get-ADForest @parameters -ErrorAction Stop

--- a/ForestManagement/functions/schemadefaultpermissions/Invoke-FMSchemaDefaultPermission.ps1
+++ b/ForestManagement/functions/schemadefaultpermissions/Invoke-FMSchemaDefaultPermission.ps1
@@ -136,6 +136,8 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type SchemaDefaultPermissions -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
+
 		try { $rootDSE = Get-ADRootDSE @parameters -ErrorAction Stop }
 		catch
 		{

--- a/ForestManagement/functions/schemadefaultpermissions/Test-FMSchemaDefaultPermission.ps1
+++ b/ForestManagement/functions/schemadefaultpermissions/Test-FMSchemaDefaultPermission.ps1
@@ -44,6 +44,7 @@
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type SchemaDefaultPermissions -Cmdlet $PSCmdlet
 		Set-FMDomainContext @parameters
+		
 		try { $rootDSE = Get-ADRootDSE @parameters -ErrorAction Stop }
 		catch
 		{

--- a/ForestManagement/functions/sitelinks/Invoke-FMSiteLink.ps1
+++ b/ForestManagement/functions/sitelinks/Invoke-FMSiteLink.ps1
@@ -52,6 +52,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type SiteLinks -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 	}
 	process {
 		if (-not $InputObject) {

--- a/ForestManagement/functions/sitelinks/Test-FMSiteLink.ps1
+++ b/ForestManagement/functions/sitelinks/Test-FMSiteLink.ps1
@@ -61,6 +61,8 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type SiteLinks -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
+		
 		$allSiteLinks = Get-ADReplicationSiteLink @parameters -Filter * -Properties Cost, Description, Options, Name, replInterval, siteList | Select-Object *
 		$linksToExclude = @()
 

--- a/ForestManagement/functions/sites/Invoke-FMSite.ps1
+++ b/ForestManagement/functions/sites/Invoke-FMSite.ps1
@@ -57,6 +57,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type Sites -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 	}
 	process
 	{

--- a/ForestManagement/functions/sites/Test-FMSite.ps1
+++ b/ForestManagement/functions/sites/Test-FMSite.ps1
@@ -61,6 +61,8 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type Sites -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
+		
 		$allSites = Get-ADReplicationSite @parameters -Filter * -Properties Location
 		$renameMapping = @{}
 		$script:sites.Values | Where-Object OldNames | ForEach-Object {

--- a/ForestManagement/functions/subnets/Invoke-FMSubnet.ps1
+++ b/ForestManagement/functions/subnets/Invoke-FMSubnet.ps1
@@ -54,6 +54,7 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type Subnets -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
 	}
 	process
 	{

--- a/ForestManagement/functions/subnets/Test-FMSubnet.ps1
+++ b/ForestManagement/functions/subnets/Test-FMSubnet.ps1
@@ -61,6 +61,8 @@
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type Subnets -Cmdlet $PSCmdlet
+		Set-FMDomainContext @parameters
+		
 		$allSubnets = Get-ADReplicationSubnet @parameters -Filter * -Properties Description | Select-Object *, @{
 			Name       = "SiteName"
 			Expression = { ($_.Site | Get-ADObject @parameters).Name }


### PR DESCRIPTION
- Fix: Name Resolution - string replacement will not always have the correct data to insert
- Fix: Exchange Schema - error message is missing when catching invalid setup.exe
- Fix: Exchange Schema - removed forced DC selection (previous change was caused by an analysis error)
- Fix: Exchange Schema - fails to update due to Organization Name being passed in